### PR TITLE
Removed property="project.description" from description pojo variable.

### DIFF
--- a/unix-maven-plugin/src/main/java/com/stratio/mojo/unix/maven/plugin/AbstractUnixMojo.java
+++ b/unix-maven-plugin/src/main/java/com/stratio/mojo/unix/maven/plugin/AbstractUnixMojo.java
@@ -69,7 +69,7 @@ public abstract class AbstractUnixMojo
     /**
      * One-line description of the package.
      *
-     * @parameter property="project.description"
+     * @parameter
      */
     protected String description;
 


### PR DESCRIPTION
 Fixed wrong variable name (project.description to description) to avoid pom error parsing

Now you can put configuration description property into a execution like this:

     <execution>
         <id>shell</id>
         <phase>package</phase>
         <configuration>
             <name>Shell</name>
     --->  <description>Shell</description>     <---
             <size>1</size>
             <assembly>
                 <copyDirectory>
                  .
                  .
                  .